### PR TITLE
Improve some code layout and an error message

### DIFF
--- a/department/archetype/final.pan
+++ b/department/archetype/final.pan
@@ -37,7 +37,7 @@ variable e = if (value('/hardware/cpu/0/arch') == 'x86_64') {
     };
 }
 else if (value('/hardware/cpu/0/arch') != value('/system/os/architecture')) {
-    error('CPU and OS architectures do not match.');
+    error('CPU and OS architectures are not compatible.');
 };
 
 # Configure repositories


### PR DESCRIPTION
Improve code layout in swap partition size logic and improve the error message when the CPU and OS architectures are not compatible.